### PR TITLE
Fix linter stdout/stderr assertions

### DIFF
--- a/src/linters/gofmt.js
+++ b/src/linters/gofmt.js
@@ -65,7 +65,7 @@ class Gofmt {
 		// start. Without these strings, this would not be possible, because file names may include
 		// spaces, which are not escaped in unified diffs. As a workaround, these lines are filtered out
 		// from the gofmt diff so the diff parser can read the diff without errors
-		const filteredOutput = output.stderr
+		const filteredOutput = output.stdout
 			.split(/\r?\n/)
 			.filter(line => !line.startsWith("diff -u"))
 			.join("\n");

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -75,12 +75,12 @@ describe.each([
 
 				// stderr
 				const stderr = normalizeDates(cmdOutput.stderr);
-				if ("stderrParts" in expected.lintResult) {
-					expected.lintResult.stderrParts.forEach(stderrParts =>
+				if ("stderrParts" in expected.cmdOutput) {
+					expected.cmdOutput.stderrParts.forEach(stderrParts =>
 						expect(stderr).toEqual(expect.stringContaining(stderrParts)),
 					);
-				} else if ("stderr" in expected.lintResult) {
-					expect(stderr).toEqual(expected.stderr);
+				} else if ("stderr" in expected.cmdOutput) {
+					expect(stderr).toEqual(expected.cmdOutput.stderr);
 				}
 			});
 

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -65,12 +65,12 @@ describe.each([
 
 				// stdout
 				const stdout = normalizeDates(cmdOutput.stdout);
-				if ("stdoutParts" in expected.lintResult) {
-					expected.lintResult.stdoutParts.forEach(stdoutPart =>
+				if ("stdoutParts" in expected.cmdOutput) {
+					expected.cmdOutput.stdoutParts.forEach(stdoutPart =>
 						expect(stdout).toEqual(expect.stringContaining(stdoutPart)),
 					);
-				} else if ("stdout" in expected.lintResult) {
-					expect(stdout).toEqual(expected.stdout);
+				} else if ("stdout" in expected.cmdOutput) {
+					expect(stdout).toEqual(expected.cmdOutput.stdout);
 				}
 
 				// stderr

--- a/test/linters/params/gofmt.js
+++ b/test/linters/params/gofmt.js
@@ -7,14 +7,14 @@ const extensions = ["go"];
 
 // Linting without auto-fixing
 function getLintParams(dir) {
-	const stderrFile1 = `diff -u file1.go.orig file1.go\n--- file1.go.orig	${TEST_DATE}\n+++ file1.go	${TEST_DATE}\n@@ -4,7 +4,7 @@\n \n var str = "world"\n \n-func main () { // Whitespace error\n+func main() { // Whitespace error\n 	fmt.Println("hello " + str)\n }\n \n@@ -17,5 +17,5 @@\n }\n \n func multiply(num1 int, num2 int) int {\n-  return num1 * num2 // Indentation error\n+	return num1 * num2 // Indentation error\n }`;
-	const stderrFile2 = `diff -u file2.go.orig file2.go\n--- file2.go.orig	${TEST_DATE}\n+++ file2.go	${TEST_DATE}\n@@ -1,5 +1,5 @@\n package main\n \n func divide(num1 int, num2 int) int {\n-	return num1 /  num2 // Whitespace error\n+	return num1 / num2 // Whitespace error\n }`;
+	const stdoutFile1 = `diff -u file1.go.orig file1.go\n--- file1.go.orig	${TEST_DATE}\n+++ file1.go	${TEST_DATE}\n@@ -4,7 +4,7 @@\n \n var str = "world"\n \n-func main () { // Whitespace error\n+func main() { // Whitespace error\n 	fmt.Println("hello " + str)\n }\n \n@@ -17,5 +17,5 @@\n }\n \n func multiply(num1 int, num2 int) int {\n-  return num1 * num2 // Indentation error\n+	return num1 * num2 // Indentation error\n }`;
+	const stdoutFile2 = `diff -u file2.go.orig file2.go\n--- file2.go.orig	${TEST_DATE}\n+++ file2.go	${TEST_DATE}\n@@ -1,5 +1,5 @@\n package main\n \n func divide(num1 int, num2 int) int {\n-	return num1 /  num2 // Whitespace error\n+	return num1 / num2 // Whitespace error\n }`;
 	return {
 		// Expected output of the linting function
 		cmdOutput: {
 			status: 0, // gofmt always uses exit code 0
-			stderrParts: [stderrFile1, stderrFile2],
-			stderr: `${stderrFile1}\n${stderrFile2}`,
+			stdoutParts: [stdoutFile1, stdoutFile2],
+			stdout: `${stdoutFile1}\n${stdoutFile2}`,
 		},
 		// Expected output of the parsing function
 		lintResult: {
@@ -50,7 +50,7 @@ function getFixParams(dir) {
 		// Expected output of the linting function
 		cmdOutput: {
 			status: 0, // gofmt always uses exit code 0
-			stderr: "",
+			stdout: "",
 		},
 		// Expected output of the parsing function
 		lintResult: {

--- a/test/linters/params/prettier.js
+++ b/test/linters/params/prettier.js
@@ -55,11 +55,13 @@ function getLintParams(dir) {
 
 // Linting with auto-fixing
 function getFixParams(dir) {
+	const stdoutFile1 = `file1.js`;
+	const stdoutFile2 = `file2.css`;
 	return {
 		// Expected output of the linting function
 		cmdOutput: {
 			status: 0,
-			// NOTE: no stdout because it includes timing output
+			stdoutParts: [stdoutFile1, stdoutFile2],
 		},
 		// Expected output of the parsing function
 		lintResult: {

--- a/test/linters/params/prettier.js
+++ b/test/linters/params/prettier.js
@@ -59,7 +59,7 @@ function getFixParams(dir) {
 		// Expected output of the linting function
 		cmdOutput: {
 			status: 0,
-			stdout: "",
+			// NOTE: no stdout because it includes timing output
 		},
 		// Expected output of the parsing function
 		lintResult: {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 const { join } = require("path");
 
-const DATE_REGEX = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d+ \+\d{4}/g;
+const DATE_REGEX = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d+ [\+-]\d{4}/g;
 const TEST_DATE = "2019-01-01 00:00:00.000000 +0000";
 
 /**

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 const { join } = require("path");
 
-const DATE_REGEX = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d+ [\+-]\d{4}/g;
+const DATE_REGEX = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d+ [+-]\d{4}/g;
 const TEST_DATE = "2019-01-01 00:00:00.000000 +0000";
 
 /**


### PR DESCRIPTION
I noticed while working on a new linter that my test was passing even though the stdout/stderr was incorrect.

This seems to be fallout from this refactor:
https://github.com/samuelmeuli/lint-action/commit/73e9574651632c461b95746ebb53b6f117d99fb6

I had to update the timezone date regex to allow my timezone as well.

I also updated the `gofmt` linter, since it sends its output to stdout. I also fixed the tests for it.

I updated the prettier test to remove the fix assertion on stdout because, on my machine, it outputs something like:

```
    Expected: ""
    Received: ".prettierrc.json 26ms
    file1.js 18ms
    file2.css 45ms
    package.json 6ms"
```

to stdout.