### PR TITLE
Use Rubocop with Bundler and allow running on arbitrary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ jobs:
 
 ### Linter-specific options
 
-`[linter]` can be one of `black`, `eslint`, `flake8`, `gofmt`, `golint`, `mypy`, `prettier`, `rubocop`, `stylelint`, `swiftformat` and `swiftlint`:
+`[linter]` can be one of `black`, `eslint`, `flake8`, `gofmt`, `golint`, `mypy`, `prettier`, `rubocop`, `rubocop_bundler`, `stylelint`, `swiftformat` and `swiftlint`:
 
 - **`[linter]`:** Enables the linter in your repository. Default: `false`
 - **`[linter]_args`**: Additional arguments to pass to the linter. Example: `eslint_args: "--max-warnings 0"` if ESLint checks should fail even if there are no errors and only warnings. Default: `""`

--- a/action.yml
+++ b/action.yml
@@ -166,6 +166,24 @@ inputs:
     required: false
     default: "rb"
 
+  # Ruby - with Bundler
+
+  rubocop_bundler:
+    description: Enable or disable RuboCop checks with bundler
+    required: false
+    default: false
+  rubocop_bundler_args:
+    description: Additional arguments to pass to the linter
+    required: false
+    default: ""
+  rubocop_bundler_dir:
+    description: Directory where the RuboCop command should be run
+    required: false
+  rubocop_bundler_extensions:
+    description: Extensions of files to check with RuboCop
+    required: false
+    default: "rb"
+
   # Swift
 
   swiftformat:

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -6,6 +6,7 @@ const Golint = require("./golint");
 const Mypy = require("./mypy");
 const Prettier = require("./prettier");
 const RuboCop = require("./rubocop");
+const RuboCopBundler = require("./rubocopBundler")
 const Stylelint = require("./stylelint");
 const SwiftFormat = require("./swiftformat");
 const SwiftLint = require("./swiftlint");
@@ -17,6 +18,7 @@ const linters = {
 	golint: Golint,
 	mypy: Mypy,
 	rubocop: RuboCop,
+	rubocop_bundler: RuboCopBundler,
 	stylelint: Stylelint,
 	swiftlint: SwiftLint,
 

--- a/src/linters/rubocop.js
+++ b/src/linters/rubocop.js
@@ -50,7 +50,7 @@ class RuboCop {
 		}
 
 		const fixArg = fix ? "--auto-correct" : "";
-		return run(`rubocop --format json ${fixArg} ${args} "."`, {
+		return run(`rubocop --format json ${fixArg} ${args}`, {
 			dir,
 			ignoreErrors: true,
 		});

--- a/src/linters/rubocopBundler.js
+++ b/src/linters/rubocopBundler.js
@@ -1,0 +1,39 @@
+const Rubocop = require("./rubocop");
+const commandExists = require("../../vendor/command-exists");
+const { run } = require("../utils/action");
+
+class RubocopBundler extends Rubocop {
+
+	/**
+	 * Verifies that all required programs are installed. Throws an error if programs are missing
+	 * @param {string} dir - Directory to run the linting program in
+	 */
+	static async verifySetup(dir) {
+		// Verify that Ruby is installed (required to execute RuboCop)
+		if (!(await commandExists("ruby"))) {
+			throw new Error("Ruby is not installed");
+		}
+	}
+
+	/**
+	 * Runs the linting program and returns the command output
+	 * @param {string} dir - Directory to run the linter in
+	 * @param {string[]} extensions - File extensions which should be linted
+	 * @param {string} args - Additional arguments to pass to the linter
+	 * @param {boolean} fix - Whether the linter should attempt to fix code style issues automatically
+	 * @returns {{status: number, stdout: string, stderr: string}} - Output of the lint command
+	 */
+	static lint(dir, extensions, args = "", fix = false) {
+		if (extensions.length !== 1 || extensions[0] !== "rb") {
+			throw new Error(`${this.name} error: File extensions are not configurable`);
+		}
+
+		const fixArg = fix ? "--auto-correct" : "";
+		return run(`bundle exec rubocop --format json ${fixArg} ${args}`, {
+			dir,
+			ignoreErrors: true,
+		});
+	}
+}
+
+module.exports = RubocopBundler;

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -12,6 +12,7 @@ const golintParams = require("./params/golint");
 const mypyParams = require("./params/mypy");
 const prettierParams = require("./params/prettier");
 const ruboCopParams = require("./params/rubocop");
+const ruboCopBundlerParams = require("./params/rubocopBundler");
 const stylelintParams = require("./params/stylelint");
 const swiftformatParams = require("./params/swiftformat");
 const swiftlintParams = require("./params/swiftlint");
@@ -26,6 +27,7 @@ const linterParams = [
 	mypyParams,
 	prettierParams,
 	ruboCopParams,
+	ruboCopBundlerParams,
 	stylelintParams,
 ];
 

--- a/test/linters/params/rubocopBundler.js
+++ b/test/linters/params/rubocopBundler.js
@@ -1,0 +1,8 @@
+const RuboCopBundler = require("../../../src/linters/rubocopBundler");
+const params = require("./rubocop");
+
+const testName = "rubocop_bundler";
+const linter = RuboCopBundler;
+const extensions = ["rb"];
+
+module.exports = [testName, linter, extensions, params[3], params[4]];


### PR DESCRIPTION
Fixes #20.

This introduces a new linter, RubocopBundler, which is identical to Rubocop but uses `bundle exec rubocop`. Rubocop allows to create a shared gem which has a rubocop.yml file so we can share a style guide across our internal projects. This means Rubocop has to be run in the context of the bundle. Unfortunately there's no real way to *prepend* rather than *append* arguments, so this is the safest way to do it.

In addition, I've removed the check for whether the rubocop command exists for this linter, since the command may *not* exist outside of `bundle exec`, and the `commandExists` function doesn't seem to work for `bundle exec rubocop`.

As part of this, I've also removed the "." in both the new and existing Rubocop linters, which allows us to pass arbitrary files into the linter.

I wasn't able to run the tests locally so here's hoping they pass on the PR 😄 