### PR TITLE
Replace `git switch` command for better compatibility

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -27,7 +27,7 @@ function checkOutRemoteBranch(context) {
 
 	// Switch to remote branch
 	log(`Switching to the "${context.branch}" branch`);
-	run(`git branch -f ${context.branch} --track ${remote}/${context.branch}`);
+	run(`git branch --force ${context.branch} --track ${remote}/${context.branch}`);
 	run(`git checkout ${context.branch}`);
 }
 

--- a/src/git.js
+++ b/src/git.js
@@ -27,7 +27,8 @@ function checkOutRemoteBranch(context) {
 
 	// Switch to remote branch
 	log(`Switching to the "${context.branch}" branch`);
-	run(`git switch --force-create ${context.branch} --track ${remote}/${context.branch}`);
+	run(`git branch -f ${context.branch} --track ${remote}/${context.branch}`);
+	run(`git checkout ${context.branch}`);
 }
 
 /**


### PR DESCRIPTION
Switch to old commands for branch switching to allow for versions of git < 2.23.0

Edit: I'll admit to not getting to actually test this except for manually issuing the commands and seeing that git seems to behave the same way.  