### PR TITLE
Fix missing `github_token` input in `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ author: Samuel Meuli
 description: GitHub Action for detecting and fixing linting errors
 
 inputs:
+  github_token:
+    description: The GITHUB_TOKEN secret
+    required: true
   auto_fix:
     description: Whether linters should try to fix code style issues automatically
     required: false


### PR DESCRIPTION
`Unexpected input 'github_token'` warning shown.
I think a cause is no `github_token` field in inputs list of action.yml.

![github_token_warning](https://user-images.githubusercontent.com/500072/82776377-abe56d00-9e85-11ea-98ac-9d9a1cc17d0c.png)

ref https://github.com/samuelmeuli/lint-action/issues/53
