### PR TITLE
Add PHP_CodeSniffer support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,14 @@ jobs:
           cd ../xo/
           yarn install
 
+      # PHP
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+          coverage: none
+          tools: phpcs
+
       # Python
 
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ _**Note:** The behavior of actions like this one is currently limited in the con
   - [ESLint](https://eslint.org)
   - [Prettier](https://prettier.io)
   - [XO](https://github.com/xojs/xo)
+- **PHP:**
+  - [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
 - **Python:**
   - [Black](https://black.readthedocs.io)
   - [Flake8](http://flake8.pycqa.org)

--- a/action.yml
+++ b/action.yml
@@ -149,6 +149,28 @@ inputs:
     required: false
     default: ""
 
+  # PHP
+
+  php_codesniffer:
+    description: Enable or disable PHP_CodeSniffer checks
+    required: false
+    default: false
+  php_codesniffer_args:
+    description: Additional arguments to pass to the linter
+    required: false
+    default: ""
+  php_codesniffer_dir:
+    description: Directory where the PHP_CodeSniffer command should be run
+    required: false
+  php_codesniffer_extensions:
+    description: Extensions of files to check with PHP_CodeSniffer
+    required: false
+    default: "php"
+  php_codesniffer_command_prefix:
+    description: Shell command to prepend to the linter command
+    required: false
+    default: ""
+
   # Python
 
   black:

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -4,6 +4,7 @@ const Flake8 = require("./flake8");
 const Gofmt = require("./gofmt");
 const Golint = require("./golint");
 const Mypy = require("./mypy");
+const PHPCodeSniffer = require("./php-codesniffer");
 const Prettier = require("./prettier");
 const RuboCop = require("./rubocop");
 const Stylelint = require("./stylelint");
@@ -18,6 +19,7 @@ const linters = {
 	flake8: Flake8,
 	golint: Golint,
 	mypy: Mypy,
+	php_codesniffer: PHPCodeSniffer,
 	rubocop: RuboCop,
 	stylelint: Stylelint,
 	swiftlint: SwiftLint,

--- a/src/linters/php-codesniffer.js
+++ b/src/linters/php-codesniffer.js
@@ -1,0 +1,98 @@
+const { log, run } = require("../utils/action");
+const commandExists = require("../utils/command-exists");
+const { initLintResult } = require("../utils/lint-result");
+const { removeTrailingPeriod } = require("../utils/string");
+
+/**
+ * https://github.com/squizlabs/PHP_CodeSniffer
+ */
+class PHPCodeSniffer {
+	static get name() {
+		return "PHP_CodeSniffer";
+	}
+
+	/**
+	 * Verifies that all required programs are installed. Throws an error if programs are missing
+	 * @param {string} dir - Directory to run the linting program in
+	 * @param {string} prefix - Prefix to the lint command
+	 */
+	static async verifySetup(dir, prefix = "") {
+		// Verify that PHP is installed (required to execute phpcs)
+		if (!(await commandExists("php"))) {
+			throw new Error("PHP is not installed");
+		}
+
+		// Verify that phpcs is installed
+		try {
+			run(`${prefix} phpcs --version`, { dir });
+		} catch (err) {
+			throw new Error(`${this.name} is not installed`);
+		}
+	}
+
+	/**
+	 * Runs the linting program and returns the command output
+	 * @param {string} dir - Directory to run the linter in
+	 * @param {string[]} extensions - File extensions which should be linted
+	 * @param {string} args - Additional arguments to pass to the linter
+	 * @param {boolean} fix - Whether the linter should attempt to fix code style issues automatically
+	 * @param {string} prefix - Prefix to the lint command
+	 * @returns {{status: number, stdout: string, stderr: string}} - Output of the lint command
+	 */
+	static lint(dir, extensions, args = "", fix = false, prefix = "") {
+		const extensionsArg = extensions.join(",");
+		if (fix) {
+			log(`${this.name} does not support auto-fixing`, "warning");
+		}
+
+		return run(`${prefix} phpcs --extensions=${extensionsArg} --report=json -q ${args} "."`, {
+			dir,
+			ignoreErrors: true,
+		});
+	}
+
+	/**
+	 * Parses the output of the lint command. Determines the success of the lint process and the
+	 * severity of the identified code style violations
+	 * @param {string} dir - Directory in which the linter has been run
+	 * @param {{status: number, stdout: string, stderr: string}} output - Output of the lint command
+	 * @returns {{isSuccess: boolean, warning: [], error: []}} - Parsed lint result
+	 */
+	static parseOutput(dir, output) {
+		const lintResult = initLintResult();
+		lintResult.isSuccess = output.status === 0;
+
+		let outputJson;
+		try {
+			outputJson = JSON.parse(output.stdout);
+		} catch (err) {
+			throw Error(
+				`Error parsing ${this.name} JSON output: ${err.message}. Output: "${output.stdout}"`,
+			);
+		}
+
+		for (const [file, violations] of Object.entries(outputJson.files)) {
+			const path = file.indexOf(dir) === 0 ? file.substring(dir.length + 1) : file;
+
+			for (const msg of violations.messages) {
+				const { line, message, source, type } = msg;
+
+				const entry = {
+					path,
+					firstLine: line,
+					lastLine: line,
+					message: `${removeTrailingPeriod(message)} (${source})`,
+				};
+				if (type === "WARNING") {
+					lintResult.warning.push(entry);
+				} else if (type === "ERROR") {
+					lintResult.error.push(entry);
+				}
+			}
+		}
+
+		return lintResult;
+	}
+}
+
+module.exports = PHPCodeSniffer;

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -10,6 +10,7 @@ const flake8Params = require("./params/flake8");
 const gofmtParams = require("./params/gofmt");
 const golintParams = require("./params/golint");
 const mypyParams = require("./params/mypy");
+const phpCodeSnifferParams = require("./params/php-codesniffer");
 const prettierParams = require("./params/prettier");
 const ruboCopParams = require("./params/rubocop");
 const stylelintParams = require("./params/stylelint");
@@ -26,6 +27,7 @@ const linterParams = [
 	gofmtParams,
 	golintParams,
 	mypyParams,
+	phpCodeSnifferParams,
 	prettierParams,
 	ruboCopParams,
 	stylelintParams,

--- a/test/linters/params/php-codesniffer.js
+++ b/test/linters/params/php-codesniffer.js
@@ -1,0 +1,62 @@
+const PHPCodeSniffer = require("../../../src/linters/php-codesniffer");
+
+const testName = "php-codesniffer";
+const linter = PHPCodeSniffer;
+const extensions = ["php"];
+
+// Linting without auto-fixing
+function getLintParams(dir) {
+	const stdoutFile1 = `"file1.php":{"errors":0,"warnings":1,"messages":[{"message":"A file should declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it should execute logic with side effects, but should not do both. The first symbol is defined on line 3 and the first side effect is on line 8.","source":"PSR1.Files.SideEffects.FoundWithSymbols","severity":5,"fixable":false,"type":"WARNING","line":1,"column":1}]}`;
+	const stdoutFile2 = `"file2.php":{"errors":2,"warnings":0,"messages":[{"message":"Opening brace of a class must be on the line after the definition","source":"PSR2.Classes.ClassDeclaration.OpenBraceNewLine","severity":5,"fixable":true,"type":"ERROR","line":5,"column":17},{"message":"A closing tag is not permitted at the end of a PHP file","source":"PSR2.Files.ClosingTag.NotAllowed","severity":5,"fixable":true,"type":"ERROR","line":10,"column":1}]}`;
+	// Files on macOS are not sorted.
+	const stdout =
+		process.platform === "darwin"
+			? `{"totals":{"errors":2,"warnings":1,"fixable":2},"files":{${stdoutFile2},${stdoutFile1}}}`
+			: `{"totals":{"errors":2,"warnings":1,"fixable":2},"files":{${stdoutFile1},${stdoutFile2}}}`;
+	return {
+		// Expected output of the linting function
+		cmdOutput: {
+			// PHP_CodeSniffer exit codes:
+			// - 0: No errors found.
+			// - 1: Errors found, but none of them can be fixed by PHPCBF.
+			// - 2: Errors found, and some can be fixed by PHPCBF.
+			status: 2,
+			stdoutParts: [stdoutFile1, stdoutFile2],
+			stdout,
+		},
+		// Expected output of the parsing function
+		lintResult: {
+			isSuccess: false,
+			warning: [
+				{
+					path: "file1.php",
+					firstLine: 1,
+					lastLine: 1,
+					message:
+						"A file should declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it should execute logic with side effects, but should not do both. The first symbol is defined on line 3 and the first side effect is on line 8 (PSR1.Files.SideEffects.FoundWithSymbols)",
+				},
+			],
+			error: [
+				{
+					path: "file2.php",
+					firstLine: 5,
+					lastLine: 5,
+					message:
+						"Opening brace of a class must be on the line after the definition (PSR2.Classes.ClassDeclaration.OpenBraceNewLine)",
+				},
+				{
+					path: "file2.php",
+					firstLine: 10,
+					lastLine: 10,
+					message:
+						"A closing tag is not permitted at the end of a PHP file (PSR2.Files.ClosingTag.NotAllowed)",
+				},
+			],
+		},
+	};
+}
+
+// Linting with auto-fixing
+const getFixParams = getLintParams; // Does not support auto-fixing -> option has no effect
+
+module.exports = [testName, linter, extensions, getLintParams, getFixParams];

--- a/test/linters/projects/php-codesniffer/file1.php
+++ b/test/linters/projects/php-codesniffer/file1.php
@@ -1,0 +1,8 @@
+<?php
+
+function helloWorld()
+{
+    echo 'Hello World';
+}
+
+helloWorld(); // "PSR1.Files.SideEffects.FoundWithSymbol" warning

--- a/test/linters/projects/php-codesniffer/file2.php
+++ b/test/linters/projects/php-codesniffer/file2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Vendor\Package;
+
+class ClassName { // "Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace" error
+    private $foo = null;
+}
+
+// "PSR2.Files.ClosingTag.NotAllowed" error
+?>

--- a/test/linters/projects/php-codesniffer/phpcs.xml.dist
+++ b/test/linters/projects/php-codesniffer/phpcs.xml.dist
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="lint-action-test">
+	<file>.</file>
+	<arg name="basepath" value="." />
+	<rule ref="PSR2"/>
+</ruleset>


### PR DESCRIPTION
Fixes #69

The following tasks have been done:

- [x] Create a new class for the linter, e.g. `src/linters/my-linter.js`. Have a look at the other files in that directory to see what functions the class needs to implement.
- [x] Import your class in the [`src/linters/index.js`](./src/linters/index.js) file.
- [x] Provide a sample project for the linter under `test/linters/projects/my-linter/`. It should be simple and contain a few linting errors which your tests will detect.
- [x] Provide the expected linting output for your sample project in a `test/linters/params/my-linter.js` file. Import this file in [`test/linters/linters.test.js`](./test/linters/linters.test.js). You can run the tests with `yarn test`.
- [x] Update the [`action.yml`](./action.yml) file with the options provided by the new linter.
- [x]  Mention your linter in the [`README.md`](./README.md) file.
- [x] Update the [test workflow file](./.github/workflows/test.yml).