### PR TITLE
Unlink Hombrew's swiftlint to fix linking by mint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,10 @@ jobs:
         run: |
           brew update
           brew install mint
+          # If installed, unlink swiftlint, workaround for https://github.com/yonaskolb/Mint/issues/182
+          brew unlink swiftlint || true
           cd ./test/linters/projects/swift-format-lockwood/
           mint bootstrap --link
-          brew unlink swiftlint
           cd ../swiftlint/
           mint bootstrap --link
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,9 @@ jobs:
         run: |
           brew update
           brew install mint
-          brew unlink swiftlint
           cd ./test/linters/projects/swift-format-lockwood/
           mint bootstrap --link
+          brew unlink swiftlint
           cd ../swiftlint/
           mint bootstrap --link
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
         run: |
           brew update
           brew install mint
+          brew unlink swiftlint
           cd ./test/linters/projects/swift-format-lockwood/
           mint bootstrap --link
           cd ../swiftlint/


### PR DESCRIPTION
Try to fix the build error in https://github.com/samuelmeuli/lint-action/pull/73/checks?check_run_id=926787280

```
🌱 Cloning SwiftFormat 0.43.5
🌱 Resolving package
🌱 Building package
🌱 Installed SwiftFormat 0.43.5
🌱 Linked swiftformat 0.43.5 to /usr/local/bin
🌱 Installed 1/1 package
🌱 Cloning SwiftLint 0.38.1
🌱 Resolving package
🌱 Building package
🌱 Installed SwiftLint 0.38.1
🌱  An executable that was not installed by mint already exists at /usr/local/bin/swiftlint that is symlinked to /usr/local/Cellar/swiftlint/0.39.2/bin/swiftlint.
Overwrite it with Mint's symlink? (y/n) 
##[error]Process completed with exit code 1.
```

Related: https://github.com/yonaskolb/Mint/issues/182