### PR TITLE
Replace `actions/setup-ruby@v1` with `ruby/setup-ruby@v1` in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
       # Ruby
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
 


### PR DESCRIPTION
There's current a hidden error in the macos-latest runner.

```
sudo ln -sf /Users/runner/hostedtoolcache/Ruby/2.6.6/x64/bin/ruby /usr/bin/ruby
ln: /usr/bin/ruby: Operation not permitted
(node:1502) UnhandledPromiseRejectionWarning: Error: The process 'sudo' failed with exit code 1
    at ExecState._setResult (/Users/runner/work/_actions/actions/setup-ruby/v1/node_modules/@actions/exec/lib/toolrunner.js:547:25)
    at ExecState.CheckComplete (/Users/runner/work/_actions/actions/setup-ruby/v1/node_modules/@actions/exec/lib/toolrunner.js:530:18)
    at ChildProcess.<anonymous> (/Users/runner/work/_actions/actions/setup-ruby/v1/node_modules/@actions/exec/lib/toolrunner.js:430:27)
    at ChildProcess.emit (events.js:210:5)
    at maybeClose (internal/child_process.js:1021:16)
    at Socket.<anonymous> (internal/child_process.js:430:11)
    at Socket.emit (events.js:210:5)
    at Pipe.<anonymous> (net.js:659:12)
(node:1502) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:1502) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Upstream issue: https://github.com/actions/setup-ruby/issues/67

The solution seems to be to use `ruby/setup-ruby@v1` which is also [recommended in the starter workflow](https://github.com/actions/starter-workflows/blob/e11672e5a9026a98ce6235af089d3112ec93dbd5/ci/ruby.yml#L23-L29).