### PR TITLE
Fix path replacement for Flake8

### DIFF
--- a/src/linters/flake8.js
+++ b/src/linters/flake8.js
@@ -69,7 +69,11 @@ class Flake8 {
 		const matches = output.stdout.matchAll(PARSE_REGEX);
 		for (const match of matches) {
 			const [_, pathFull, line, rule, text] = match;
-			const path = pathFull.substring(2); // Remove "./" or ".\" from start of path
+			const leadingSep = `.${sep}`;
+			let path = pathFull;
+			if (path.startsWith(leadingSep)) {
+				path = path.substring(2); // Remove "./" or ".\" from start of path
+			}
 			const lineNr = parseInt(line, 10);
 			lintResult.error.push({
 				path,


### PR DESCRIPTION
Fixes #64. 

This adds the same code as already used in https://github.com/samuelmeuli/lint-action/blob/d99462ff1ed51fc7931b756e47392208d3988e04/src/linters/mypy.js#L84-L88.