### PR TITLE
Add action input for custom check names

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ jobs:
 
 - **`commit_message`**: Template for auto-fix commit messages. The `${linter}` variable can be used to insert the name of the linter. Default: `"Fix code style issues with ${linter}"`
 
+- **`check_name`**: Template for the [name of the check run](https://docs.github.com/en/rest/reference/checks#create-a-check-run). Use this to ensure unique names when the action is used more than once in a workflow. The `${linter}` and `${dir}` variables can be used to insert the name and directory of the linter. Default: `"${linter}"`
+
 ### Linter support
 
 Some options are not be available for specific linters:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: "Fix code style issues with ${linter}"
   check_name:
-    description: 'Template for the name of the check. The "${linter}" and "${dir}" variables can be used to insert the name and directory of the linter. The default directory is omitted.'
+    description: 'Template for the name of the check run. The "${linter}" and "${dir}" variables can be used to insert the name and directory of the linter.'
     required: false
     default: "${linter}"
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Template for auto-fix commit messages. The "${linter}" variable can be used to insert the name of the linter which has created the auto-fix'
     required: false
     default: "Fix code style issues with ${linter}"
+  check_name:
+    description: 'Template for the name of the check. The "${linter}" and "${dir}" variables can be used to insert the name and directory of the linter. The default directory is omitted.'
+    required: false
+    default: "${linter}"
 
   # CSS
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ async function runAction() {
 	const gitName = getInput("git_name", true);
 	const gitEmail = getInput("git_email", true);
 	const commitMessage = getInput("commit_message", true);
+	const checkName = getInput("check_name", true);
 
 	// If on a PR from fork: Display messages regarding action limitations
 	if (context.eventName === "pull_request" && context.repository.hasFork) {
@@ -94,7 +95,12 @@ async function runAction() {
 				}
 			}
 
-			checks.push({ checkName: linter.name, lintResult, summary });
+			const lintCheckName = checkName
+				.replace(/\${linter}/g, linter.name)
+				.replace(/\${dir}/g, lintDirRel !== "." ? `${lintDirRel}` : "")
+				.trim();
+
+			checks.push({ lintCheckName, lintResult, summary });
 		}
 	}
 
@@ -104,8 +110,8 @@ async function runAction() {
 	log(""); // Create empty line in logs
 	const headSha = git.getHeadSha();
 	await Promise.all(
-		checks.map(({ checkName, lintResult, summary }) =>
-			createCheck(checkName, headSha, context, lintResult, summary),
+		checks.map(({ lintCheckName, lintResult, summary }) =>
+			createCheck(lintCheckName, headSha, context, lintResult, summary),
 		),
 	);
 }


### PR DESCRIPTION
Fixes #61.

Example with `check_name: "${linter} (${dir})"`
![image](https://user-images.githubusercontent.com/617637/89124000-e7c72f00-d4d3-11ea-905c-c9f9b8ee1a89.png)
